### PR TITLE
feat: Introduce the `norg` function to replace `Base.parse` usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ julia> s = """
        But it's easier to read if you use a link description, as in this link towards {https://klafyvel.me}[my *website*] !
        """;
 
-julia> parse(HTMLTarget, s) |> Pretty
+julia> norg(HTMLTarget(), s) |> Pretty
 # pretty HTML prints there, but have a look at its rendering below
 
 julia> norg"Neorg also has a string macro that can be used in Pluto"
@@ -83,7 +83,7 @@ s = open(Norg.NORG_SPEC_PATH, "r") do f
     read(f, String)
 end;
 open("1.0-specification.html", "w") do f
-    write(f, string(parse(Norg.HTMLTarget, s)|>Pretty))
+    write(f, string(norg(HTMLTarget(), s)|>Pretty))
 end
 ```
 
@@ -93,7 +93,7 @@ Norg files to pandoc!
 ```julia
 import JSON
 open("1.0-specification.json", "w") do f
-  JSON.print(f, parse(Norg.JSONTarget, s), 2)
+  JSON.print(f, norg(JSONTarget(), s), 2)
 end;
 ```
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ s = open(Norg.NORG_SPEC_PATH, "r") do f
     read(f, String)
 end;
 md_path = joinpath(@__DIR__, "src", "1.0-specification.md")
-ast = parse(Norg.AST.NorgDocument, s)
+ast = norg(s)
 function mk_toc(ast)
     toc_tree = filter(!isnothing, [mk_toc(ast, c) for c in children(ast)])
 end
@@ -50,7 +50,7 @@ open(md_path, "w") do f
     write(f, "```@raw html\n")
     write(f, string(toc_html|>Pretty))
     write(f, "\n")
-    write(f, string(parse(Norg.HTMLTarget(), s)|>Pretty))
+    write(f, string(norg(Norg.HTMLTarget(), s)|>Pretty))
     write(f, "\n```")
 end
 

--- a/src/Norg.jl
+++ b/src/Norg.jl
@@ -64,16 +64,27 @@ using .Codegen
 
 
 """
-    parse(HTMLTarget(), s)
-    parse(JSONTarget(), s)
+    norg([codegentarget, ] s)
 
-Parse a Norg string to the specified targets.
+Parse the input `s` to an AST. If codegentarget is included, return the result
+of code generation for the given target.
 
-See also: [`HTMLTarget`](@ref), [`JSONTarget`](@ref)
+# Examples
+```julia-repl
+julia> norg("* Hello world!")
+NorgDocument
+└─ (K"Heading1", 2, 8)
+   └─ (K"ParagraphSegment", 4, 7)
+      ├─ Hello
+      ├─
+      ├─ world
+      └─ !
+julia> norg(HTMLTarget(), "* Hello world!")
+<div class="norg"><section id="section-h1-hello-world"><h1 id="h1-hello-world">Hello world&#33;</h1></section><section class="footnotes"><ol></ol></section></div>
+```
 """
-Base.parse(::Type{T}, s) where {T <: Codegen.CodegenTarget} = codegen(T(), parse_norg(tokenize(s)))
-Base.parse(t::T, s) where {T <: Codegen.CodegenTarget} = codegen(t, parse_norg(tokenize(s)))
-
+norg(s)= parse_norg(tokenize(s))
+norg(t::T, s) where {T <: Codegen.CodegenTarget} = codegen(t, norg(s))
 
 """
 Easily parse Norg string to an AST. This can be used in *e.g.* Pluto notebooks,
@@ -92,7 +103,7 @@ NorgDocument
       └─ Example
 """
 macro norg_str(s, t ...)
-	parse(AST.NorgDocument, s)
+	norg(s)
 end
 
 function Base.show(io::IO, ::MIME"text/html", ast::AST.NorgDocument)
@@ -100,6 +111,6 @@ function Base.show(io::IO, ::MIME"text/html", ast::AST.NorgDocument)
 end
 
 export HTMLTarget, JSONTarget
-export @norg_str
+export @norg_str, norg
 
 end

--- a/src/parser/parser.jl
+++ b/src/parser/parser.jl
@@ -20,15 +20,6 @@ import ..consume_until
 import ..findtargets!
 
 """
-    parse(AST.NorgDocument, s)
-
-Produce an [`AST.NorgDocument`](@ref) from a string `s`. Calls [`Tokenize.tokenize`](@ref).
-"""
-function Base.parse(::Type{AST.NorgDocument}, s::AbstractString)
-    parse_norg(Tokenize.tokenize(s))
-end
-
-"""
     parse_norg(strategy, tokens, i)
 
 Try to parse the `tokens` sequence starting at index `i` using a given `strategy`.


### PR DESCRIPTION
BREAKING CHANGE: The `Base.parse` methods for Norg.jl have been removed.

Fix #11 .